### PR TITLE
Update v1.0.8

### DIFF
--- a/src/main/java/me/twoeggs/maphelper/MapHelper.java
+++ b/src/main/java/me/twoeggs/maphelper/MapHelper.java
@@ -18,7 +18,6 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/me/twoeggs/maphelper/MapHelper.java
+++ b/src/main/java/me/twoeggs/maphelper/MapHelper.java
@@ -158,7 +158,7 @@ public class MapHelper {
                 display2 = "West of Barbarian Village";
                 break;
             case "19":
-                display = "compass set 264 63 -695";
+                display = "/compass set 264 63 -695";
                 display2 = "YSITARLIK; Krystilia in Edgeville";
                 break;
             case "20":


### PR DESCRIPTION
Update to fix two bugs, one that crashes builders when they use their builders wand (made a catch-all for any items that do not have the word "clue" in their name,) and one command missing it's required forward-slash in order to be executed and not just sent in chat.